### PR TITLE
Add utility to invert Comms polling dependency

### DIFF
--- a/include/tbc/Battle.hpp
+++ b/include/tbc/Battle.hpp
@@ -28,6 +28,7 @@ template <
   typename TEvent,
   SimultaneousActionStrategy TSimultaneousActionStrategy>
 class Battle {
+public:
   using TBattle                = Battle<TState, TCommand, TCommandResult, TEvent, TSimultaneousActionStrategy>;
   using TComms                 = Comms<TBattle, TCommand, TCommandResult>;
   using TPlayerComms           = PlayerComms<TBattle, TCommand, TCommandResult>;
@@ -42,7 +43,11 @@ class Battle {
   using TCommandOrderer          = std::function<std::vector<TCommand>(const std::vector<TCommand> &, const TBattle &)>;
   using TTurnStartCommandChecker = std::function<TCommandPayloadTypeSet(std::size_t, const TBattle &)>;
 
-public:
+  using State         = TState;
+  using Command       = TCommand;
+  using CommandResult = TCommandResult;
+  using Event         = TEvent;
+
   constexpr static auto SimultaneousActionStrategy = TSimultaneousActionStrategy;
 
   Battle(const TState &state_, std::vector<TPlayerComms> comms)

--- a/include/tbc/util/comms/PlayerClientCommsAdapter.hpp
+++ b/include/tbc/util/comms/PlayerClientCommsAdapter.hpp
@@ -1,0 +1,37 @@
+#ifndef TBC_UTIL_COMMS_PLAYERCLIENTCOMMSADAPTER_HPP
+#define TBC_UTIL_COMMS_PLAYERCLIENTCOMMSADAPTER_HPP
+
+namespace ngl::tbc::comms {
+template <typename TBattle>
+class PlayerClientCommsAdapter {
+  using TCommand           = typename TBattle::Command;
+  using TCommandResult     = typename TBattle::CommandResult;
+  using TCommandPayload    = typename TCommand::Payload;
+  using TCommandPayloadSet = typename TCommand::PayloadTypeSet;
+  using TPlayerComms       = typename TBattle::TPlayerComms;
+
+public:
+  PlayerClientCommsAdapter(std::size_t players) : proxies{players} {}
+  [[nodiscard]] std::vector<TPlayerComms> MakePlayerComms() {
+    std::vector<TPlayerComms> out;
+    for (auto &proxy : proxies) {
+      auto player = PlayerComms{
+        "Proxy Player", // TODO: fix this naming sometime
+        [&proxy](const TCommandPayloadSet &valid, const Battle &battle) {
+          return proxy.CommsRequestCallback(valid, battle);
+        }
+      };
+      player.SetResponseHandler(
+        [&proxy](const TCommandResult &result) {
+          proxy.CommsResponseCallback(result);
+        }
+
+      );
+      out.push_back(player);
+    }
+    return out;
+  }
+
+  std::vector<PlayerClientProxy<TBattle>> proxies;
+};
+} // namespace ngl::tbc::comms

--- a/include/tbc/util/comms/PlayerClientCommsAdapter.hpp
+++ b/include/tbc/util/comms/PlayerClientCommsAdapter.hpp
@@ -1,6 +1,10 @@
 #ifndef TBC_UTIL_COMMS_PLAYERCLIENTCOMMSADAPTER_HPP
 #define TBC_UTIL_COMMS_PLAYERCLIENTCOMMSADAPTER_HPP
 
+#include <vector>
+
+#include "tbc/util/comms/PlayerClientProxy.hpp"
+
 namespace ngl::tbc::comms {
 template <typename TBattle>
 class PlayerClientCommsAdapter {
@@ -15,9 +19,9 @@ public:
   [[nodiscard]] std::vector<TPlayerComms> MakePlayerComms() {
     std::vector<TPlayerComms> out;
     for (auto &proxy : proxies) {
-      auto player = PlayerComms{
+      auto player = TPlayerComms{
         "Proxy Player", // TODO: fix this naming sometime
-        [&proxy](const TCommandPayloadSet &valid, const Battle &battle) {
+        [&proxy](const TCommandPayloadSet &valid, const TBattle &battle) {
           return proxy.CommsRequestCallback(valid, battle);
         }
       };
@@ -35,3 +39,5 @@ public:
   std::vector<PlayerClientProxy<TBattle>> proxies;
 };
 } // namespace ngl::tbc::comms
+
+#endif

--- a/include/tbc/util/comms/PlayerClientProxy.hpp
+++ b/include/tbc/util/comms/PlayerClientProxy.hpp
@@ -1,0 +1,70 @@
+#ifndef TBC_UTIL_COMMS_PLAYERCLIENTPROXY_HPP
+#define TBC_UTIL_COMMS_PLAYERCLIENTPROXY_HPP
+
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
+namespace ngl::tbc::comms {
+template <typename TBattle>
+class PlayerClientProxy {
+  using TCommand           = typename TBattle::Command;
+  using TCommandResult     = typename TBattle::CommandResult;
+  using TCommandPayload    = typename TCommand::Payload;
+  using TCommandPayloadSet = typename TCommand::PayloadTypeSet;
+
+public:
+  [[nodiscard]] bool NeedsCommands() {
+    std::unique_lock<std::mutex> lock(request_mutex_);
+    return valid_payloads_.has_value();
+  }
+
+  [[nodiscard]] TCommandResult ProvideCommands(const std::vector<TCommandPayload> &payloads) {
+    {
+      std::unique_lock<std::mutex> request_lock(request_mutex_);
+      request_ = payloads;
+      request_ready_.notify_all();
+    }
+
+    std::unique_lock<std::mutex> response_lock(response_mutex_);
+    response_ready_.wait(response_lock, [this]() {
+      return response_.has_value();
+    });
+    const auto out = response_.value();
+    response_      = std::nullopt;
+    return out;
+  }
+
+  [[nodiscard]] std::vector<TCommandPayload> CommsRequestCallback(const TCommandPayloadSet &valid_payloads) {
+    std::unique_lock<std::mutex> lock(request_mutex_);
+    valid_payloads_ = valid_payloads;
+    request_ready_.wait(lock, [this]() {
+      return request_.has_value();
+    });
+
+    const auto out  = request_.value();
+    request_        = std::nullopt;
+    valid_payloads_ = std::nullopt;
+    return out;
+  }
+
+  void CommsResponseCallback(const CommandResult &result) {
+    std::unique_lock<std::mutex> lock(response_mutex_);
+    response_ = result;
+    response_ready_.notify_all();
+  }
+
+protected:
+  std::mutex request_mutex_;
+  std::condition_variable request_ready_;
+  std::optional<std::vector<TCommandPayload>> request_;
+  std::optional<TCommandPayloadSet> valid_payloads_;
+
+  std::mutex response_mutex_;
+  std::condition_variable response_ready_;
+  std::optional<TCommandResult> response_;
+};
+
+} // namespace ngl::tbc::comms
+
+#endif

--- a/include/tbc/util/comms/PlayerClientProxy.hpp
+++ b/include/tbc/util/comms/PlayerClientProxy.hpp
@@ -35,7 +35,7 @@ public:
     return out;
   }
 
-  [[nodiscard]] std::vector<TCommandPayload> CommsRequestCallback(const TCommandPayloadSet &valid_payloads) {
+  [[nodiscard]] std::vector<TCommandPayload> CommsRequestCallback(const TCommandPayloadSet &valid_payloads, const TBattle &battle) {
     std::unique_lock<std::mutex> lock(request_mutex_);
     valid_payloads_ = valid_payloads;
     request_ready_.wait(lock, [this]() {
@@ -48,7 +48,7 @@ public:
     return out;
   }
 
-  void CommsResponseCallback(const CommandResult &result) {
+  void CommsResponseCallback(const TCommandResult &result) {
     std::unique_lock<std::mutex> lock(response_mutex_);
     response_ = result;
     response_ready_.notify_all();


### PR DESCRIPTION
Resolves #53; adds a utility that provides PlayerComms objects that model initiating contact with the Battle, rather than being polled for Commands